### PR TITLE
Added *.csv files to the .gitignore so that client information is not…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-#ignore csv files of database data
-*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#ignore csv files of database data
+*.csv

--- a/import.py
+++ b/import.py
@@ -1,7 +1,0 @@
-import csv
-import os
-import psycopg2
-import psycopg2.extras
-import click
-from flask import current_app, g
-from flask.cli import with_appcontext


### PR DESCRIPTION
Added .csv files to the git ignore.....

recognized that having our clients information on our public git hub is a big security risk.

tomorrow i'll ask the team if its ok to delete the file on git, and then we can copy the information locally into the directory every time we run the import-csv command to input our data.

