### PR TITLE
unindenet import csv bugfix

### DIFF
--- a/portal/db.py
+++ b/portal/db.py
@@ -126,7 +126,8 @@ def import_csv():
                         (hashed, password[0]))
 
                     g.db.commit()
-                    cur.close()
+
+                cur.close()
 
 
 @click.command("import-csv")


### PR DESCRIPTION
a line of code in our import-csv function was accidentally indented.

unindented to allow function to work.